### PR TITLE
Add basic benchmarking framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # BenchmarkingQuantumHardwareML
+
+This repository contains a simple framework for benchmarking different quantum
+hardware backends on machine learning tasks. The goal is to provide a minimal
+interface for integrating hardware providers and ML tasks so they can be
+evaluated in a uniform way.
+
+## Structure
+
+- `benchmarking/hardware.py` – abstractions and a tiny single-qubit simulator.
+- `benchmarking/tasks.py` – task definitions. Includes a toy parity
+  classification task.
+- `benchmarking/benchmark.py` – orchestration utilities and a CLI for running
+  benchmarks.
+
+## Running
+
+Execute the default benchmark using the simple simulator:
+
+```bash
+python -m benchmarking.benchmark
+```
+
+This will run all tasks on the simulator and print the resulting metrics.

--- a/benchmarking/benchmark.py
+++ b/benchmarking/benchmark.py
@@ -1,0 +1,30 @@
+from typing import Iterable, Dict, Any
+
+from .hardware import QuantumHardware, SimpleSimulator
+from .tasks import MLTask, ParityClassificationTask
+
+def benchmark(hardwares: Iterable[QuantumHardware], tasks: Iterable[MLTask]) -> Dict[str, Dict[str, Any]]:
+    """Run all tasks on all hardware backends."""
+    results: Dict[str, Dict[str, Any]] = {}
+    for hw in hardwares:
+        hw_name = hw.__class__.__name__
+        results[hw_name] = {}
+        for task in tasks:
+            results[hw_name][task.name] = task.run(hw)
+    return results
+
+
+def main():
+    hardware = [SimpleSimulator()]
+    tasks = [ParityClassificationTask()]
+    results = benchmark(hardware, tasks)
+    for hw_name, task_results in results.items():
+        print(f"Results for {hw_name}:")
+        for task_name, metrics in task_results.items():
+            metric_str = ", ".join(f"{k}={v:.3f}" for k, v in metrics.items())
+            print(f"  {task_name}: {metric_str}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/benchmarking/hardware.py
+++ b/benchmarking/hardware.py
@@ -1,0 +1,39 @@
+from abc import ABC, abstractmethod
+from typing import List
+import math
+import random
+
+class QuantumHardware(ABC):
+    """Abstract base class for quantum hardware backends."""
+
+    @abstractmethod
+    def run_circuit(self, circuit: List[str]) -> int:
+        """Execute a simple single-qubit circuit.
+
+        The circuit is represented as a list of gate names. Supported gates:
+        "H" for Hadamard, "X" for Pauli-X, "Z" for Pauli-Z.
+        Returns a classical measurement result (0 or 1).
+        """
+        raise NotImplementedError
+
+
+class SimpleSimulator(QuantumHardware):
+    """Very small single-qubit simulator using Python complex numbers."""
+
+    def run_circuit(self, circuit: List[str]) -> int:
+        # Start in |0>
+        state = [1+0j, 0+0j]
+        for gate in circuit:
+            if gate == "H":
+                s0 = (state[0] + state[1]) / math.sqrt(2)
+                s1 = (state[0] - state[1]) / math.sqrt(2)
+                state = [s0, s1]
+            elif gate == "X":
+                state = [state[1], state[0]]
+            elif gate == "Z":
+                state = [state[0], -state[1]]
+            else:
+                raise ValueError(f"Unsupported gate: {gate}")
+        prob1 = abs(state[1]) ** 2
+        return 1 if random.random() < prob1 else 0
+

--- a/benchmarking/tasks.py
+++ b/benchmarking/tasks.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from typing import Dict
+
+from .hardware import QuantumHardware
+
+class MLTask(ABC):
+    """Base class for ML tasks."""
+
+    name: str
+
+    @abstractmethod
+    def run(self, hardware: QuantumHardware) -> Dict[str, float]:
+        """Execute the task using the provided hardware and return metrics."""
+        raise NotImplementedError
+
+
+class ParityClassificationTask(MLTask):
+    """Toy task that measures whether the hardware can flip a qubit."""
+
+    def __init__(self):
+        self.name = "ParityClassification"
+
+    def run(self, hardware: QuantumHardware) -> Dict[str, float]:
+        correct = 0
+        for bit in (0, 1):
+            circuit = ["X"] if bit == 1 else []
+            result = hardware.run_circuit(circuit)
+            if result == bit:
+                correct += 1
+        accuracy = correct / 2
+        return {"accuracy": accuracy}
+


### PR DESCRIPTION
## Summary
- create simple benchmarking package with minimal single-qubit simulator
- implement a toy parity classification task
- add CLI entry point for running benchmarks
- document running instructions in README

## Testing
- `python -m benchmarking.benchmark`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c591345e0832d948b83ded9a14652